### PR TITLE
ci: Fix release workflow permissions

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -32,6 +32,9 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/cd-publish.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
### Summary

Fixes the `cd-release.yml` → `cd-publish.yml` workflow_call permission error. The publish workflow requests `id-token: write` (needed for npm `--provenance`), but the calling workflow didn't grant that permission, causing a `startup_failure`.

- Fixes: N/A
- Time to review: 2 minutes

### Changes proposed

- [`cd-release.yml`](https://github.com/common-grants/ts-cg-grants-gov/pull/6/files#diff-cd-release) — Adds `permissions: contents: read, id-token: write` to the `publish` job so the callee workflow can request `id-token: write`

### Context for reviewers

**Why this failed here but not in test-release-workflow:** The test repo's `cd-publish.yml` only requested `permissions: contents: read` (no `id-token`) because it does a dry-run publish without `--provenance`. The real repo's `cd-publish.yml` requests `id-token: write` for npm provenance attestation. When a workflow is invoked via `workflow_call`, the caller's permissions are the ceiling — the callee cannot escalate beyond what the caller grants.

**Reproduced and fixed in test repo:**
1. Added `id-token: write` to the test repo's `cd-publish.yml` to reproduce the error ([widal001/test-release-workflow#15](https://github.com/widal001/test-release-workflow/pull/15))
2. Applied the same fix — job-level permissions on the `publish` job in `cd-release.yml` ([widal001/test-release-workflow#16](https://github.com/widal001/test-release-workflow/pull/16))
3. Verified full end-to-end: `feat:` PR → release PR → merge → publish triggered successfully ([run](https://github.com/widal001/test-release-workflow/actions/runs/24102980429))

### Additional information

#### [Original failure in this repo](https://github.com/common-grants/ts-cg-grants-gov/actions/runs/24102061247)

<img width="1419" height="671" alt="Screenshot 2026-04-07 at 4 37 23 PM" src="https://github.com/user-attachments/assets/49ea9ea5-9d89-4896-b941-febd6bfd94ce" />

#### [Replicated failure on widal001/test-release-workflow](https://github.com/widal001/test-release-workflow/actions/runs/24102542286)

<img width="1440" height="900" alt="Screenshot 2026-04-07 at 4 40 53 PM" src="https://github.com/user-attachments/assets/5052d17c-6214-4567-aac4-f51ae402b940" />

#### [Demonstrated fix on widal001/test-release-workflow](https://github.com/widal001/test-release-workflow/actions/runs/24102980429)

<img width="1440" height="900" alt="Screenshot 2026-04-07 at 4 41 54 PM" src="https://github.com/user-attachments/assets/b31efee0-7d19-41c2-9a4f-cfaea379dedd" />