### PR TITLE
ci: Adds changelog to `.prettierignore`

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -40,8 +40,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Runs CI checks, builds, tests, and audits the package
-      - run: pnpm run ci
+      # Builds the package
+      # TODO: Change this back to pnpm run ci after initial release
+      - run: pnpm run build
 
       - name: Publish
         env:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .github/
+CHANGELOG.md


### PR DESCRIPTION
### Summary

Adds `CHANGELOG.md` to `.prettierignore` and temporarily changes `cd-publish.yml` so we can publish the previous release.

The [previous publish run](https://github.com/common-grants/ts-cg-grants-gov/actions/runs/24144855935) failed because the auto-generated `CHANGELOG.md` was flagged by `pnpm format`.

- Fixes N/A
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds `CHANGELOG.md` to `.prettierignore` since it's automatically generated by release-please and is getting flagged by `pnpm check:format`
- Temporarily switches to just run `pnpm build` since for the manual deploy, we'll be checking out the code at the previous `v0.1.0` tag to publish, which doesn't include the `.prettierignore` update.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

- Since the issue was specific to the CI steps of the `cd-publish.yml` workflow and we're using a `ci:` prefix on this PR, Release Please shouldn't create a new release PR and we shouldn't need to revert the previous release commit.
- After this is merged in I'll trigger the `cd-publish.yml` from the Actions tab and pass in the `v0.1.0` tag.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1440" height="900" alt="Screenshot 2026-04-08 at 12 31 29 PM" src="https://github.com/user-attachments/assets/766ce39a-1dac-4ef0-95e0-d4d37ce6582d" />
