### PR TITLE
ci: Fix release step

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -29,8 +29,6 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Removing the version 10 from the cd-publish step as this conflicts with the version of pnpm that is in the project.
