### PR TITLE
ci: drop pnpm version pin from workflows

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -29,8 +29,6 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.34.3
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
### Summary

- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Removed the `version:` input from `pnpm/action-setup@v5` in both `ci.yml` and `cd-publish.yml`.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The `publish` job started failing with `ERR_PNPM_BAD_PM_VERSION`:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.34.3 in the package.json with the key "packageManager"
```

`pnpm/action-setup@v5` floats to the latest v5.x, and a recent release made specifying *both* a `version:` input **and** a `packageManager` field in `package.json` a hard error — it wants a single source of truth. It errors even when the two agree, so `ci.yml` (`version: 10.34.3`, matching `packageManager`) hits the same break.

Fix: drop the workflow pin in both files and let `packageManager` (`pnpm@10.34.3`) be the source of truth.

Verified against the failing run: https://github.com/common-grants/ts-cg-grants-gov/actions/runs/28127395942/job/83299306768 — this PR's CI run is the verification that the setup step now resolves pnpm correctly.