### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -42,9 +42,10 @@ jobs:
       # TODO: Change this back to pnpm run ci after initial release
       - run: pnpm run build
 
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 bundles an older npm.
+      - run: npm install -g npm@latest
+
+      # Tokenless publish via npm trusted publishing; provenance is emitted
+      # automatically for a public repo + public package.
       - name: Publish
-        env:
-          # TODO: Replace with trusted publishers after initial release
-          # https://github.com/common-grants/ts-cg-grants-gov/issues/4
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --provenance --access public --no-git-checks
+        run: npm publish --access public

--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -42,10 +42,9 @@ jobs:
       # TODO: Change this back to pnpm run ci after initial release
       - run: pnpm run build
 
-      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 bundles an older npm.
+      # pnpm publish shells out to the system npm, which must be >= 11.5.1 for
+      # OIDC trusted publishing; Node 22 bundles an older npm.
       - run: npm install -g npm@latest
 
-      # Tokenless publish via npm trusted publishing; provenance is emitted
-      # automatically for a public repo + public package.
       - name: Publish
-        run: npm publish --access public
+        run: pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
### Summary

- Closes #4
- Time to review: 3 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Migrates the npm publish step (`cd-publish.yml`) from token auth to **trusted publishing (OIDC)** — no long-lived npm token, and provenance is emitted automatically.

- Removes `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`.
- Upgrades npm to `>= 11.5.1` before publishing (Node 22 bundles npm 10.x, which predates OIDC trusted-publishing support).
- Publishes with `npm publish --access public` instead of `pnpm publish` (pnpm v10 delegates to the npm CLI; `npm publish` is npm's documented OIDC path). Provenance is automatic for a public repo + public package, so the explicit `--provenance` flag is dropped.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The 0.2.0 publish originally failed because there was **no `NPM_TOKEN` secret** set — `secrets.NPM_TOKEN` resolved to empty, npm received an unauthenticated PUT and masked it as `E404`. 0.2.0 has since been published manually via the old token method, so **this PR is purely the durable upgrade for future releases** — no backfill is involved.

**One manual step on npmjs.com is required after merge** — configure a GitHub Actions trusted publisher for `@common-grants/cg-grants-gov` (Settings → Trusted Publisher):

| Field | Value |
|---|---|
| Organization or user | `common-grants` |
| Repository | `ts-cg-grants-gov` |
| Workflow filename | `cd-release.yml` |
| Environment name | `npm` |
| Allowed actions | `npm publish` |

The filename is `cd-release.yml` (not `cd-publish.yml`) because releases run `cd-release.yml` → `uses: ./cd-publish.yml`, and npm validates the **calling** workflow for reusable-workflow publishes.

`id-token: write` is already set on both the `cd-release.yml` caller job and the `cd-publish.yml` job, and `repository.url` already matches the repo — both OIDC requirements. The `workflow_dispatch` trigger on `cd-publish.yml` is left in place as a break-glass manual path (it would need the trusted-publisher filename pointed at `cd-publish.yml` temporarily to authenticate).